### PR TITLE
🐛 fix: wrong theme

### DIFF
--- a/src/layouts/Blank.vue
+++ b/src/layouts/Blank.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-[#414448] h-[100vh]">
+  <div data-theme="dark" class="bg-base-200 h-[100vh]">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
Closes #9 

🎨 style(Blank.vue): update background color class and add data-theme attribute

The background color class in the template of Blank.vue has been updated from "bg-[#414448]" to "bg-base-200" for better consistency with the design system. Additionally, a data-theme attribute with the value "dark" has been added to the div element.